### PR TITLE
Various textual fixes

### DIFF
--- a/ZIGI.V1R0.PANELS/ZIGIDSNA
+++ b/ZIGI.V1R0.PANELS/ZIGIDSNA
@@ -14,8 +14,9 @@
 +
 + Enter a prefix to add datasets under that prefix to the repo via the list
 + below. When you select%N+above to not keep the prefix, datsets in the repo
-+ will not have that prefix. If you select%Y+this repository will%permanently+
-+ use that prefix. This means don't add datasets with different prefixes.
++ will not have that prefix. If you select%N+the prefix entered will be the
++ prefix for the full repository, meaning you%can't add+datasets with a prefix
++ other than the one you select here.
 +
 %S  Status         Dataset Name
 )Model

--- a/ZIGI.V1R0.PANELS/ZIGIDSNB
+++ b/ZIGI.V1R0.PANELS/ZIGIDSNB
@@ -9,13 +9,13 @@
 +\-\#(z ISPF Git Dataset Add)+-\-\
 %Command ===>_zcmd        \ \ %Scroll ===>_zscr+
 +
-%Enter Dataset Prefix: $dsnapfx                               +
+%Fixed Dataset Prefix: $dsnapfx                               +
 %Keep the prefix in the repo:$z+(%Y+or%N+)
 +
-+ Enter a prefix to add datasets under that prefix to the repo via the list
-+ below. When you select%N+above to not keep the prefix, datsets in the repo
-+ will not have that prefix. If you select%Y+this repository will%permanently+
-+ use that prefix. This means don't add datasets with different prefixes.
++ You've selected to not keep the prefix. Only datsets with the prefix you
++ selected are elligible to be added to the repository.
++
++
 +
 %S  Status         Dataset Name
 )Model


### PR DESCRIPTION
Make it more clear once a user selects a prefix for a repo, it's a fixed prefix